### PR TITLE
Ditch astw-babylon and use babel directly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/index.js
+++ b/index.js
@@ -36,11 +36,14 @@ var handlers = {
       return item.left.property.name;
     },
     opts: function (item) {
-      var classDeclaration = item.parent.parent.parent.parent.parent;
-      if (classDeclaration) {
-        return { class: classDeclaration.id.name };
+      var parent = item.parent;
+      while (parent && !["ClassDeclaration", "FunctionDeclaration"].includes(parent.type)) {
+        parent = parent.parent;
+      }
+      if (!parent) {
+        return {};
       } else {
-        return { class: item.parent.parent.parent.id.name };
+        return {class: parent.id.name};
       }
   }},
   VariableDeclarator: {type: 'v'},

--- a/index.js
+++ b/index.js
@@ -82,6 +82,7 @@ function processItem (filename) {
 
 function tag (item, filename, type, opts, _name) {
   var name = _name || item[item.id ? 'id' : item.key ? 'key' : 'local'].name;
+  if (!name) return;
   var tag = [
     name,
     filename,

--- a/index.js
+++ b/index.js
@@ -5,9 +5,9 @@ Code licensed under the MIT License.
 See LICENSE.txt
 */
 
-var astw = require('astw-babylon');
+var path = require('path');
+var fs = require('fs');
 var glob = require('glob');
-
 
 console.log("!_TAG_FILE_FORMAT	2	/extended format/");
 console.log("!_TAG_FILE_SORTED	0	/0=unsorted, 1=sorted, 2=foldcase/");
@@ -18,8 +18,30 @@ console.log("!_TAG_PROGRAM_VERSION	"+require('./package').version+"	//");
 
 var handlers = {
   ClassDeclaration: {type: 'c'},
+  ClassProperty: {type: 'm', opts: function(item){
+    return {class: item.parent.parent.id.name};
+  }},
+  ClassMethod: {type: 'm', opts: function(item){
+    return {class: item.parent.parent.id.name};
+  }},
   MethodDefinition: {type: 'f', opts: function(item){
     return {class: item.parent.parent.id.name};
+  }},
+  AssignmentExpression: {type: function (item) {
+    if (item.left.type === "MemberExpression" && item.left.object.type === "ThisExpression") {
+      return 'm';
+    }
+  }, 
+    name: function(item) {
+      return item.left.property.name;
+    },
+    opts: function (item) {
+      var classDeclaration = item.parent.parent.parent.parent.parent;
+      if (classDeclaration) {
+        return { class: classDeclaration.id.name };
+      } else {
+        return { class: item.parent.parent.parent.id.name };
+      }
   }},
   VariableDeclarator: {type: 'v'},
   ImportDefaultSpecifier: {type: 'i'},
@@ -35,24 +57,28 @@ var filePattern = process.argv[2];
 glob.sync(filePattern).forEach(doFile);
 
 function doFile (filename) {
-  var walk = astw(require('fs').readFileSync(filename).toString());
+  var walk = astw(path.resolve(filename), fs.readFileSync(filename).toString());
 
   walk(processItem(filename));
 }
 
 function processItem (filename) {
   return function (item) {
+    if (!item.loc) return;
     var handler = handlers[item.type];
     if (handler) {
       var type = typeof handler.type === 'function' ? handler.type(item) : handler.type;
-      var opts = typeof handler.opts === 'function' ? handler.opts(item) : {};
-      tag(item, filename, type, opts);
+      if (type) {
+        var opts = typeof handler.opts === 'function' ? handler.opts(item) : {};
+        var name = handler.name && handler.name(item);
+        tag(item, filename, type, opts, name);
+      }
     }
   };
 }
 
-function tag (item, filename, type, opts) {
-  var name = item[item.id ? 'id' : item.key ? 'key' : 'local'].name;
+function tag (item, filename, type, opts, _name) {
+  var name = _name || item[item.id ? 'id' : item.key ? 'key' : 'local'].name;
   var tag = [
     name,
     filename,
@@ -63,4 +89,37 @@ function tag (item, filename, type, opts) {
     tag.push(optname+':'+opts[optname]);
   });
   console.log(tag.join('\t'));
+}
+
+function astw(filename, src) {
+  return function (cb) {
+    var babelCore = require('babel-core');
+    var File = babelCore.File;
+    var Pipeline = babelCore.Pipeline;
+    var ast = new File({filename:  filename}, new Pipeline()).parse(src);
+    walk(ast.program.body, undefined, cb);
+  };
+  function walk (node, parent, cb) {
+    var keys = Object.keys(node);
+    for (var i = 0; i < keys.length; i++) {
+      var key = keys[i];
+      if (key === 'parent') continue;
+
+      var child = node[key];
+      if (Array.isArray(child)) {
+        for (var j = 0; j < child.length; j++) {
+          var c = child[j];
+          if (c && typeof c.type === 'string') {
+            c.parent = node;
+            walk(c, node, cb);
+          }
+        }
+      }
+      else if (child && typeof child.type === 'string') {
+        child.parent = node;
+        walk(child, node, cb);
+      }
+    }
+    cb(node);
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,444 @@
+{
+  "name": "btags",
+  "version": "1.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+    },
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "requires": {
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
+      }
+    },
+    "babel-core": {
+      "version": "6.26.3",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+      "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
+      "requires": {
+        "babel-code-frame": "^6.26.0",
+        "babel-generator": "^6.26.0",
+        "babel-helpers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-register": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "convert-source-map": "^1.5.1",
+        "debug": "^2.6.9",
+        "json5": "^0.5.1",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.4",
+        "path-is-absolute": "^1.0.1",
+        "private": "^0.1.8",
+        "slash": "^1.0.0",
+        "source-map": "^0.5.7"
+      }
+    },
+    "babel-generator": {
+      "version": "6.26.1",
+      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
+      "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+      "requires": {
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "detect-indent": "^4.0.0",
+        "jsesc": "^1.3.0",
+        "lodash": "^4.17.4",
+        "source-map": "^0.5.7",
+        "trim-right": "^1.0.1"
+      }
+    },
+    "babel-helpers": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+      "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
+      }
+    },
+    "babel-messages": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-register": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
+      "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+      "requires": {
+        "babel-core": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "home-or-tmp": "^2.0.0",
+        "lodash": "^4.17.4",
+        "mkdirp": "^0.5.1",
+        "source-map-support": "^0.4.15"
+      }
+    },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "requires": {
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
+      }
+    },
+    "babel-template": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+      "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "lodash": "^4.17.4"
+      }
+    },
+    "babel-traverse": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+      "requires": {
+        "babel-code-frame": "^6.26.0",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "debug": "^2.6.8",
+        "globals": "^9.18.0",
+        "invariant": "^2.2.2",
+        "lodash": "^4.17.4"
+      }
+    },
+    "babel-types": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.4",
+        "to-fast-properties": "^1.0.3"
+      }
+    },
+    "babylon": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "requires": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "convert-source-map": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
+      "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+      "requires": {
+        "safe-buffer": "~5.1.1"
+      }
+    },
+    "core-js": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "detect-indent": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+      "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+      "requires": {
+        "repeating": "^2.0.0"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "glob": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "globals": {
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "home-or-tmp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+      "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+      "requires": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.1"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "requires": {
+        "loose-envify": "^1.0.0"
+      }
+    },
+    "is-finite": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+      "requires": {
+        "number-is-nan": "^1.0.0"
+      }
+    },
+    "js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+    },
+    "jsesc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+      "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+    },
+    "json5": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+    },
+    "lodash": {
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "private": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
+    },
+    "regenerator-runtime": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+    },
+    "repeating": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "requires": {
+        "is-finite": "^1.0.0"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "slash": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+    },
+    "source-map-support": {
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+      "requires": {
+        "source-map": "^0.5.6"
+      }
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+    },
+    "to-fast-properties": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+    },
+    "trim-right": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "astw-babylon": "^1.0.0",
+    "babel-core": "^6.26.3",
     "glob": "^7.1.1"
   }
 }

--- a/test/file.js
+++ b/test/file.js
@@ -25,3 +25,5 @@ function Bar () {
 }
 
 Bar.prototype.bonk = 2;
+
+const { c, d } = {};

--- a/test/file.js
+++ b/test/file.js
@@ -4,7 +4,11 @@ import {john as jack} from "joe";
 
 class FooFoo extends Foo {
   constructor () {
-    this.x = 2
+    this.x = 2;
+
+    if (a) {
+      this.y = 3;
+    }
   }
 
   foo (cb) {

--- a/test/output.txt
+++ b/test/output.txt
@@ -9,12 +9,13 @@ q	test/file.js	2;"	i
 r	test/file.js	2;"	i
 jack	test/file.js	3;"	i
 x	test/file.js	7;"	m	class:FooFoo
+y	test/file.js	10;"	m	class:FooFoo
 constructor	test/file.js	6;"	m	class:FooFoo
-foo	test/file.js	10;"	m	class:FooFoo
+foo	test/file.js	14;"	m	class:FooFoo
 FooFoo	test/file.js	5;"	c
-x	test/file.js	15;"	v
-y	test/file.js	16;"	v
-a	test/file.js	17;"	v
-b	test/file.js	17;"	v
-baz	test/file.js	20;"	m	class:Bar
-Bar	test/file.js	19;"	c
+x	test/file.js	19;"	v
+y	test/file.js	20;"	v
+a	test/file.js	21;"	v
+b	test/file.js	21;"	v
+baz	test/file.js	24;"	m	class:Bar
+Bar	test/file.js	23;"	c

--- a/test/output.txt
+++ b/test/output.txt
@@ -1,0 +1,20 @@
+!_TAG_FILE_FORMAT	2	/extended format/
+!_TAG_FILE_SORTED	0	/0=unsorted, 1=sorted, 2=foldcase/
+!_TAG_PROGRAM_AUTHOR	Bryan English	/bryan@bryanenglish.com/
+!_TAG_PROGRAM_NAME	btags	//
+!_TAG_PROGRAM_URL	http://github.com/bengl/btags	/github repository/
+!_TAG_PROGRAM_VERSION	{{{VERSION}}}	//
+Foo	test/file.js	1;"	i
+q	test/file.js	2;"	i
+r	test/file.js	2;"	i
+jack	test/file.js	3;"	i
+x	test/file.js	7;"	m	class:FooFoo
+constructor	test/file.js	6;"	m	class:FooFoo
+foo	test/file.js	10;"	m	class:FooFoo
+FooFoo	test/file.js	5;"	c
+x	test/file.js	15;"	v
+y	test/file.js	16;"	v
+a	test/file.js	17;"	v
+b	test/file.js	17;"	v
+baz	test/file.js	20;"	m	class:Bar
+Bar	test/file.js	19;"	c

--- a/test/test.js
+++ b/test/test.js
@@ -3,31 +3,25 @@ var path = require('path');
 
 var version = require('../package').version;
 
-var expectedOutput = '!_TAG_FILE_FORMAT\t2\t/extended format/\n' +
-'!_TAG_FILE_SORTED\t0\t/0=unsorted, 1=sorted, 2=foldcase/\n' +
-'!_TAG_PROGRAM_AUTHOR\tBryan English\t/bryan@bryanenglish.com/\n' +
-'!_TAG_PROGRAM_NAME\tbtags\t//\n' +
-'!_TAG_PROGRAM_URL\thttp://github.com/bengl/btags\t/github repository/\n' +
-'!_TAG_PROGRAM_VERSION\t' + version + '\t//\n' +
-'Foo\ttest/file.js\t1;"\ti\n' +
-'q\ttest/file.js\t2;"\ti\n' +
-'r\ttest/file.js\t2;"\ti\n' +
-'jack\ttest/file.js\t3;"\ti\n' +
-'constructor\ttest/file.js\t6;"\tf\tclass:FooFoo\n' +
-'foo\ttest/file.js\t10;"\tf\tclass:FooFoo\n' +
-'FooFoo\ttest/file.js\t5;"\tc\n' +
-'x\ttest/file.js\t15;"\tv\n' +
-'y\ttest/file.js\t16;"\tv\n' +
-'a\ttest/file.js\t17;"\tv\n' +
-'b\ttest/file.js\t17;"\tv\n' +
-'Bar\ttest/file.js\t19;"\tc\n';
+var expectedOutput = require('fs')
+  .readFileSync(path.resolve(__dirname, 'output.txt'), {encoding: 'utf8'})
+  .replace('{{{VERSION}}}', version);
 
 var runFile = path.resolve(__dirname, '..', 'index.js');
 exec('node ' + runFile + ' test/file.js', function(err, stdout, stderr){
   if (err) {
     throw err;
   }
-  console.log(stdout.toString());
-  console.assert(stdout.toString() === expectedOutput);
+
+  var expectedLines = expectedOutput.split('\n');
+  var outputLines = stdout.toString().split('\n');
+  for (var i = 0; i < outputLines.length; i++) {
+    var test = outputLines[i] === expectedLines[i];
+    console.assert(test, `got "${outputLines[i]}" expected "${expectedLines[i]}"`);
+    if (!test) { 
+      console.log('failed');
+      process.exit(1);
+    }
+  }
   console.log('passed');
 });


### PR DESCRIPTION
astw-babylon hasn't been updated in 3 years. This PR ditches it an uses babel-core directly. 
Using babel-core directly lets us pick up .babelrc configs automatically, so that btags doesn't choke on added syntax plugins.
Also added handlers for class methods, class properties and `this.` assignments inside class members.